### PR TITLE
Handle errors better for single-user groks

### DIFF
--- a/octohat/helpers.py
+++ b/octohat/helpers.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from connection import Connection, Pager
+from exceptions import ResponseError
 
 token = os.environ.get("GITHUB_TOKEN")
 conn = Connection(token)
@@ -44,8 +45,11 @@ def get_code_commentors(repo_name, limit):
 
 
 def get_data(uri):
-    resp = conn.send("GET", uri)
-    return resp.json()
+    try: 
+      resp = conn.send("GET", uri)
+      return resp.json()
+    except ResponseError, e: 
+      return None
 
 
 def get_pri_count(repo_name):
@@ -63,7 +67,10 @@ def get_user_data(entry):
 def get_user(uri):
     progress_advance()
     entry = get_data(uri)
-    return [get_user_data(entry)]
+    if entry is not None:
+        return [get_user_data(entry)]
+    else:
+        return []
 
 def get_users(uri):
     users = []

--- a/octohat/response.py
+++ b/octohat/response.py
@@ -10,6 +10,7 @@
 import re
 
 from utils import AttrDict, get_logger
+from exceptions import ResponseError#, OctohubError
 
 log = get_logger('response')
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 
 setup(
     name='octohat',
-    version='0.0.1',
+    version='0.0.2',
     description='Non-code contribution groker for GitHub',
     long_description=long_description,
     url='https://github.com/glasnt/octohat',


### PR DESCRIPTION
Requires basic handling for 404s on single gets, and importing exceptions, which for some reason wasn't working earlier