### PR TITLE
Ensure simplejson is installed as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         #'Programming Language :: Python :: 3',
     ],
     keywords='octohat github contributions non-code',
-    install_requires=['requests'],
+    install_requires=['requests', 'simplejson'],
     entry_points={
       'console_scripts': [ "octohat = octohat:main" ]
     },


### PR DESCRIPTION
Thanks for the PyCon AU talk and for sharing, it was awesome.  I'll be sharing the blog post around #LABHR.

Simplejson needs to be defined as dependency to ensure it's installed (eg from PyPI).  Without it, the exceptions.py file throws an ImportError if simplejson isn't installed, as it wasn't for me.

From looking/trying octohub, it appears simplejson isn't specifically needed over the ``json`` module in the standard library so the one reference to ``import simplejson as json`` could be replaced with just ``import json``, and this dependency removed.  Since the code's from upstream in Octohub, that's a better discussion for over there.