### PR TITLE
Add a local entrypoint for executing the local code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,14 @@ Usage
 
 Define an environment variable for "GITHUB_TOKEN" to use an `authentication token`_ (allows for deeper searching)
 
+Run this repo locally
+---------------------
+
+.. code-block::
+    git clone https://github.com/glasnt/octohat
+    cd octohat
+    python3 octocat.py [arguments]
+
 
 To do
 -----

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Run this repo locally
 .. code-block::
     git clone https://github.com/glasnt/octohat
     cd octohat
-    python3 octocat.py [arguments]
+    python3 octohat.py [arguments]
 
 
 To do

--- a/octohat.py
+++ b/octohat.py
@@ -1,0 +1,2 @@
+import octohat
+octohat.main()


### PR DESCRIPTION
This was annoying me during development. But now, I can use whatever's local without having to `pip install . -e` or whatnot.