### PR TITLE
Request for Comment: Parent Repo processing

### DIFF
--- a/octohat/__init__.py
+++ b/octohat/__init__.py
@@ -15,11 +15,25 @@ def main():
 
   repo_name = args.repo_name
 
+
   if not repo_exists(repo_name): 
     print("Repo does not exist: %s" % repo_name)
     sys.exit(1)
 
   code_contributors = get_code_contributors(repo_name)
+
+  if is_fork(repo_name):
+    parent = get_fork_parent(repo_name)
+    parent_contributors = get_code_contributors(parent)
+
+    unique = []
+    for user in code_contributors:
+      if user["user_name"] not in [k["user_name"] for k in parent_contributors]:
+        unique.append(user)
+  
+    print([k["user_name"] for k in unique])
+    code_contributors = unique
+    
   code_commentors = get_code_commentors(repo_name, args.limit)
 
   non_code_contributors = []

--- a/octohat/helpers.py
+++ b/octohat/helpers.py
@@ -121,6 +121,15 @@ def progress_advance():
 def progress_complete():
     sys.stdout.write("\n")
 
+def get_fork_parent(repo):
+    data = get_data("/repos/%s" % repo)
+    print(data["parent"])
+    return data["parent"]["full_name"]
+
+def is_fork(repo):
+    data = get_data("/repos/%s" % repo)
+    return data["fork"]
+
 def get_user_name(login):
     user = get_data("/users/%s" % login)
     if user["name"] is None: user["name"] = login


### PR DESCRIPTION
For a repo that's a fork, we _could_ take the subsection of contributors that have committed on the fork but not parent as that repos contributors

But I do not believe this is valid, because the contributors to a fork should include all the people who helped build the parent. Also, github fork workflows etcetc. Also, given current methods, it's nigh impossible to determine if someone has contributed to a fork if they also happen to have an upstream comment, as they'd cancel themselves out.

Any comments on this are welcome.